### PR TITLE
Rename Fragment::get_link_id and set_link_id to get_element_id and set_element_id

### DIFF
--- a/unittest/Fragment_serialization_test.cxx
+++ b/unittest/Fragment_serialization_test.cxx
@@ -50,9 +50,9 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_trigger_timestamp(), test_frag.get_trigger_timestamp());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_begin(), test_frag.get_window_begin());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_end(), test_frag.get_window_end());
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().system_type, test_frag.get_link_id().system_type);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().region_id, test_frag.get_link_id().region_id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().element_id, test_frag.get_link_id().element_id);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().system_type, test_frag.get_element_id().system_type);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().region_id, test_frag.get_element_id().region_id);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().element_id, test_frag.get_element_id().element_id);
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_error_bits(), test_frag.get_error_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_fragment_type_code(), test_frag.get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_size(), test_frag.get_size());
@@ -94,9 +94,9 @@ BOOST_AUTO_TEST_CASE(SerDes_JSON)
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_trigger_timestamp(), test_frag.get_trigger_timestamp());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_begin(), test_frag.get_window_begin());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_end(), test_frag.get_window_end());
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().system_type, test_frag.get_link_id().system_type);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().region_id, test_frag.get_link_id().region_id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_link_id().element_id, test_frag.get_link_id().element_id);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().system_type, test_frag.get_element_id().system_type);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().region_id, test_frag.get_element_id().region_id);
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().element_id, test_frag.get_element_id().element_id);
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_error_bits(), test_frag.get_error_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_fragment_type_code(), test_frag.get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_size(), test_frag.get_size());


### PR DESCRIPTION
Depends on DUNE-DAQ/dataformats#66