### PR TITLE
Added run_number, sequence_number, and source_pid fields to the TimeSync message

### DIFF
--- a/include/dfmessages/TimeSync.hpp
+++ b/include/dfmessages/TimeSync.hpp
@@ -24,6 +24,9 @@ struct TimeSync
 {
   timestamp_t daq_time{ TypeDefaults::s_invalid_timestamp };        ///< The current DAQ time
   system_time_t system_time{ TypeDefaults::s_invalid_system_time }; ///< The current system time
+  run_number_t run_number{ 0 };
+  size_t sequence_number{ 0 };
+  size_t source_pid{ 0 };
 
   TimeSync() = default;
 
@@ -50,7 +53,7 @@ struct TimeSync
     return static_cast<system_time_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
   }
 
-  DUNE_DAQ_SERIALIZE(TimeSync, daq_time, system_time);
+  DUNE_DAQ_SERIALIZE(TimeSync, daq_time, system_time, run_number, sequence_number, source_pid);
 };
 } // namespace dfmessages
 } // namespace dunedaq

--- a/include/dfmessages/TimeSync.hpp
+++ b/include/dfmessages/TimeSync.hpp
@@ -24,9 +24,9 @@ struct TimeSync
 {
   timestamp_t daq_time{ TypeDefaults::s_invalid_timestamp };        ///< The current DAQ time
   system_time_t system_time{ TypeDefaults::s_invalid_system_time }; ///< The current system time
-  run_number_t run_number{ 0 };
-  size_t sequence_number{ 0 };
-  size_t source_pid{ 0 };
+  uint64_t sequence_number{ 0 };                                    ///< Sequence Number of this message, for debugging
+  run_number_t run_number{ 0 };                                     ///< Run number at time of creation
+  uint32_t source_pid{ 0 };                                         ///< PID of the creating process, for debugging
 
   TimeSync() = default;
 


### PR DESCRIPTION
…to reduce leakage between runs and aid in debugging.

This PullRequest is for changes related to the addition of a run number, sequence number, and source process PID to TimeSync messages.  The run number will be used to ensure that only TimeSync messages from the current run are used, and the sequence number and source_pid fields are included for debugging purposes.  (For example, I’ve used the source_pid to verify that only TimeSyncs from Readout App 1 show up in DQM App 1, etc, *and* that all TimeSync messages show up in the Fake HSI App.)

There are correlated code changes in four repositories for this addition.
dfmessages, branch kbiery/TimeSyncRunNumber
dqm, branch kbiery/TimeSyncRunNumber
readoutlibs, branch kbiery/TimeSyncRunNumber
timinglibs, branch kbiery/TimeSyncRunNumber

Reviewer(s), please take a look at the changes and verify that things are working correctly.  Once the changes in all four packages have been reviewed, we’ll merge them to the respective develop branches.
Thanks!
