### PR TITLE
Fix trigger_type_mask member of TRMonRequest

### DIFF
--- a/include/dfmessages/TRMonRequest.hpp
+++ b/include/dfmessages/TRMonRequest.hpp
@@ -25,11 +25,11 @@ struct TRMonRequest
 {
 
   request_number_t request_number{ TypeDefaults::s_invalid_request_number }; ///< The number of the request
-  trigger_type_t trigger_type{ TypeDefaults::s_invalid_trigger_type }; ///< The trigger type that is being requested
+  trigger_type_t trigger_type_mask{ TypeDefaults::s_invalid_trigger_type }; ///< The trigger type(s) that are being requested
   run_number_t run_number{ TypeDefaults::s_invalid_run_number };       ///< The current run number
   std::string data_destination; ///< The Monitoring destination that the TR should be sent to
 
-  DUNE_DAQ_SERIALIZE(TRMonRequest, request_number, trigger_type, run_number, data_destination);
+  DUNE_DAQ_SERIALIZE(TRMonRequest, request_number, trigger_type_mask, run_number, data_destination);
 };
 
 /**
@@ -38,7 +38,7 @@ struct TRMonRequest
 class TRMonTriggerTypes
 {
 public:
-  static constexpr trigger_type_t s_any_trigger_type = 0xffff;
+  static constexpr trigger_type_t s_any_trigger_type = 0xffffffffffffffff;
 };
 
 } // namespace dfmessages

--- a/unittest/TRMonRequest_test.cxx
+++ b/unittest/TRMonRequest_test.cxx
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
 
   TRMonRequest dr;
   dr.request_number = 1;
-  dr.trigger_type = 2;
+  dr.trigger_type_mask = 2;
   dr.run_number = 3;
   dr.data_destination = "test";
 
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
   TRMonRequest dr_deserialized = dunedaq::serialization::deserialize<TRMonRequest>(bytes);
 
   BOOST_REQUIRE_EQUAL(dr.request_number, dr_deserialized.request_number);
-  BOOST_REQUIRE_EQUAL(dr.trigger_type, dr_deserialized.trigger_type);
+  BOOST_REQUIRE_EQUAL(dr.trigger_type_mask, dr_deserialized.trigger_type_mask);
   BOOST_REQUIRE_EQUAL(dr.run_number, dr_deserialized.run_number);
   BOOST_REQUIRE_EQUAL(dr.data_destination, dr_deserialized.data_destination);
 }


### PR DESCRIPTION
Since trigger_type is a bitfield, the TRMonRequest member is acutally a trigger_type_mask for matching requests. This also makes the s_any_trigger_type define make more sense, but it should be 64 bits to match the width of the field.

Part of the changes for https://github.com/DUNE-DAQ/dfmodules/pull/439