### PR TITLE
Johnfreeman/merge patch branches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dfmessages VERSION 2.10.0)
+project(dfmessages VERSION 2.11.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/dfmessages/TRMonRequest.hpp
+++ b/include/dfmessages/TRMonRequest.hpp
@@ -25,11 +25,11 @@ struct TRMonRequest
 {
 
   request_number_t request_number{ TypeDefaults::s_invalid_request_number }; ///< The number of the request
-  trigger_type_t trigger_type{ TypeDefaults::s_invalid_trigger_type }; ///< The trigger type that is being requested
+  trigger_type_t trigger_type_mask{ TypeDefaults::s_invalid_trigger_type }; ///< The trigger type(s) that are being requested
   run_number_t run_number{ TypeDefaults::s_invalid_run_number };       ///< The current run number
   std::string data_destination; ///< The Monitoring destination that the TR should be sent to
 
-  DUNE_DAQ_SERIALIZE(TRMonRequest, request_number, trigger_type, run_number, data_destination);
+  DUNE_DAQ_SERIALIZE(TRMonRequest, request_number, trigger_type_mask, run_number, data_destination);
 };
 
 /**
@@ -38,7 +38,7 @@ struct TRMonRequest
 class TRMonTriggerTypes
 {
 public:
-  static constexpr trigger_type_t s_any_trigger_type = 0xffff;
+  static constexpr trigger_type_t s_any_trigger_type = 0xffffffffffffffff;
 };
 
 } // namespace dfmessages

--- a/unittest/TRMonRequest_test.cxx
+++ b/unittest/TRMonRequest_test.cxx
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
 
   TRMonRequest dr;
   dr.request_number = 1;
-  dr.trigger_type = 2;
+  dr.trigger_type_mask = 2;
   dr.run_number = 3;
   dr.data_destination = "test";
 
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
   TRMonRequest dr_deserialized = dunedaq::serialization::deserialize<TRMonRequest>(bytes);
 
   BOOST_REQUIRE_EQUAL(dr.request_number, dr_deserialized.request_number);
-  BOOST_REQUIRE_EQUAL(dr.trigger_type, dr_deserialized.trigger_type);
+  BOOST_REQUIRE_EQUAL(dr.trigger_type_mask, dr_deserialized.trigger_type_mask);
   BOOST_REQUIRE_EQUAL(dr.run_number, dr_deserialized.run_number);
   BOOST_REQUIRE_EQUAL(dr.data_destination, dr_deserialized.data_destination);
 }


### PR DESCRIPTION
`johnfreeman/merge_patch_branches` is a branch which was forked off from `develop` and proceeded to have `patch/fddaq-v5.4.x` merged in; as such, this PR is intended to de-facto bring in code changes from `patch/fddaq-v5.4.x`. A successful test build was performed earlier today using all available `johnfreeman/merge_patch_branches` across repos (`MRGFD_DEV_250908_A9`, https://github.com/DUNE-DAQ/daq-release/actions/runs/17558744520) and integration tests were fully successful (https://github.com/DUNE-DAQ/daq-release/actions/runs/17561050175). 