### PR TITLE
Modified TimeSync messages to include the SourceID::id instead of a source process ID

### DIFF
--- a/include/dfmessages/TimeSync.hpp
+++ b/include/dfmessages/TimeSync.hpp
@@ -32,7 +32,7 @@ struct TimeSync
   /// Run number at time of creation
   run_number_t run_number{ 0 };
   /// SourceID::id of the creating DAQModule, for debugging
-  uint32_t source_id; // NOLINT(build/unsigned)
+  uint32_t source_id{ 0 }; // NOLINT(build/unsigned)
 
   TimeSync() = default;
 

--- a/include/dfmessages/TimeSync.hpp
+++ b/include/dfmessages/TimeSync.hpp
@@ -9,7 +9,6 @@
 #ifndef DFMESSAGES_INCLUDE_DFMESSAGES_TIMESYNC_HPP_
 #define DFMESSAGES_INCLUDE_DFMESSAGES_TIMESYNC_HPP_
 
-#include "dfmessages/SourceID_serialization.hpp"
 #include "dfmessages/Types.hpp"
 
 #include "serialization/Serialization.hpp"
@@ -32,8 +31,8 @@ struct TimeSync
   uint64_t sequence_number{ 0 }; // NOLINT(build/unsigned)
   /// Run number at time of creation
   run_number_t run_number{ 0 };
-  /// SourceID of the creating DAQModule, for debugging
-  SourceID source_id;
+  /// SourceID::id of the creating DAQModule, for debugging
+  uint32_t source_id; // NOLINT(build/unsigned)
 
   TimeSync() = default;
 
@@ -62,7 +61,7 @@ struct TimeSync
 
   DUNE_DAQ_SERIALIZE(TimeSync, daq_time, system_time, run_number, sequence_number, source_id);
 };
-static_assert(sizeof(TimeSync) == 40, "TimeSync size unexpected!");
+static_assert(sizeof(TimeSync) == 32, "TimeSync size unexpected!");
 static_assert(offsetof(TimeSync, daq_time) == 0, "TimeSync daq_time field not at expected offset!");
 static_assert(offsetof(TimeSync, system_time) == 8, "TimeSync system_time field not at expected offset!");
 static_assert(offsetof(TimeSync, sequence_number) == 16, "TimeSync sequence_number field not at expected offset!");

--- a/include/dfmessages/TimeSync.hpp
+++ b/include/dfmessages/TimeSync.hpp
@@ -9,6 +9,7 @@
 #ifndef DFMESSAGES_INCLUDE_DFMESSAGES_TIMESYNC_HPP_
 #define DFMESSAGES_INCLUDE_DFMESSAGES_TIMESYNC_HPP_
 
+#include "dfmessages/SourceID_serialization.hpp"
 #include "dfmessages/Types.hpp"
 
 #include "serialization/Serialization.hpp"
@@ -31,8 +32,8 @@ struct TimeSync
   uint64_t sequence_number{ 0 }; // NOLINT(build/unsigned)
   /// Run number at time of creation
   run_number_t run_number{ 0 };
-  /// PID of the creating process, for debugging
-  uint32_t source_pid{ 0 }; // NOLINT(build/unsigned)
+  /// SourceID of the creating DAQModule, for debugging
+  SourceID source_id;
 
   TimeSync() = default;
 
@@ -59,14 +60,14 @@ struct TimeSync
     return static_cast<system_time_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
   }
 
-  DUNE_DAQ_SERIALIZE(TimeSync, daq_time, system_time, run_number, sequence_number, source_pid);
+  DUNE_DAQ_SERIALIZE(TimeSync, daq_time, system_time, run_number, sequence_number, source_id);
 };
-static_assert(sizeof(TimeSync) == 32, "TimeSync size unexpected!");
+static_assert(sizeof(TimeSync) == 40, "TimeSync size unexpected!");
 static_assert(offsetof(TimeSync, daq_time) == 0, "TimeSync daq_time field not at expected offset!");
 static_assert(offsetof(TimeSync, system_time) == 8, "TimeSync system_time field not at expected offset!");
 static_assert(offsetof(TimeSync, sequence_number) == 16, "TimeSync sequence_number field not at expected offset!");
 static_assert(offsetof(TimeSync, run_number) == 24, "TimeSync run_number field not at expected offset!");
-static_assert(offsetof(TimeSync, source_pid) == 28, "TimeSync source_pid field not at expected offset!");
+static_assert(offsetof(TimeSync, source_id) == 28, "TimeSync source_id field not at expected offset!");
 } // namespace dfmessages
 DUNE_DAQ_SERIALIZABLE(dfmessages::TimeSync, "TimeSync");
 } // namespace dunedaq


### PR DESCRIPTION
## Description

These changes are part of a set of changes that are described in DUNE-DAQ/daq-deliverables#188.  Overall, the goal is to eliminate the use of Linux process IDs in identifying the source of TimeSync messages (to avoid problems with their use in certain environments) and use DAQ SourceID information instead.

Please see the `daq-deliverables` Issue for more details, including the full set of repositories that have correlated changes.

## Testing Suggestions

Please see DUNE-DAQ/daq-deliverables#188.
