### PR TITLE
Update usage of FragmentErrorBits to FragmentStatusBits

### DIFF
--- a/unittest/Fragment_serialization_test.cxx
+++ b/unittest/Fragment_serialization_test.cxx
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(SerDes_MsgPack)
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_end(), test_frag.get_window_end());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().subsystem, test_frag.get_element_id().subsystem);
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().id, test_frag.get_element_id().id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_error_bits(), test_frag.get_error_bits());
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_status_bits(), test_frag.get_status_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_fragment_type_code(), test_frag.get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_size(), test_frag.get_size());
 
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(Ptr_SerDes_MsgPack)
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_window_end(), test_frag->get_window_end());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_element_id().subsystem, test_frag->get_element_id().subsystem);
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_element_id().id, test_frag->get_element_id().id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized->get_error_bits(), test_frag->get_error_bits());
+  BOOST_REQUIRE_EQUAL(frag_deserialized->get_status_bits(), test_frag->get_status_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_fragment_type_code(), test_frag->get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_size(), test_frag->get_size());
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(Ptr_to_Fragment)
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_window_end(), test_frag->get_window_end());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().subsystem, test_frag->get_element_id().subsystem);
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_element_id().id, test_frag->get_element_id().id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized.get_error_bits(), test_frag->get_error_bits());
+  BOOST_REQUIRE_EQUAL(frag_deserialized.get_status_bits(), test_frag->get_status_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_fragment_type_code(), test_frag->get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized.get_size(), test_frag->get_size());
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(Fragment_to_Ptr)
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_window_end(), test_frag.get_window_end());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_element_id().subsystem, test_frag.get_element_id().subsystem);
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_element_id().id, test_frag.get_element_id().id);
-  BOOST_REQUIRE_EQUAL(frag_deserialized->get_error_bits(), test_frag.get_error_bits());
+  BOOST_REQUIRE_EQUAL(frag_deserialized->get_status_bits(), test_frag.get_status_bits());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_fragment_type_code(), test_frag.get_fragment_type_code());
   BOOST_REQUIRE_EQUAL(frag_deserialized->get_size(), test_frag.get_size());
 

--- a/unittest/TriggerRecordHeader_serialization_test.cxx
+++ b/unittest/TriggerRecordHeader_serialization_test.cxx
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
   header->set_trigger_number(10);
   header->set_trigger_timestamp(11);
   header->set_trigger_type(12);
-  header->set_error_bit(TriggerRecordErrorBits::kMismatch, true);
-  header->set_error_bit(TriggerRecordErrorBits::kUnassigned3, true);
+  header->set_status_bit(TriggerRecordStatusBits::kMismatch, true);
+  header->set_status_bit(TriggerRecordStatusBits::kUnassigned3, true);
 
   BOOST_REQUIRE_THROW(header->at(header->get_header().num_requested_components), std::range_error);
   BOOST_REQUIRE_THROW((*header)[header->get_header().num_requested_components], std::range_error);
@@ -69,9 +69,9 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
   delete header; // NOLINT(build/raw_ownership)
 
   BOOST_REQUIRE_EQUAL(copy_header.get_run_number(), 9);
-  BOOST_REQUIRE_EQUAL(copy_header.get_error_bit(static_cast<TriggerRecordErrorBits>(0)), false);
-  BOOST_REQUIRE_EQUAL(copy_header.get_error_bit(static_cast<TriggerRecordErrorBits>(1)), true);
-  BOOST_REQUIRE_EQUAL(copy_header.get_header().error_bits, 10);
+  BOOST_REQUIRE_EQUAL(copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
+  BOOST_REQUIRE_EQUAL(copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
+  BOOST_REQUIRE_EQUAL(copy_header.get_header().status_bits, 10);
   BOOST_REQUIRE_EQUAL(copy_header.at(0).window_begin, 3);
   BOOST_REQUIRE_EQUAL(copy_header[1].window_begin, 7);
 
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     // Test copy constructor
     TriggerRecordHeader copy_copy_header(copy_header);
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_run_number(), 9);
-    BOOST_REQUIRE_EQUAL(copy_copy_header.get_error_bit(static_cast<TriggerRecordErrorBits>(0)), false);
-    BOOST_REQUIRE_EQUAL(copy_copy_header.get_error_bit(static_cast<TriggerRecordErrorBits>(1)), true);
-    BOOST_REQUIRE_EQUAL(copy_copy_header.get_header().error_bits, 10);
+    BOOST_REQUIRE_EQUAL(copy_copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
+    BOOST_REQUIRE_EQUAL(copy_copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
+    BOOST_REQUIRE_EQUAL(copy_copy_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(copy_copy_header.at(0).window_begin, 3);
     BOOST_REQUIRE_EQUAL(copy_copy_header[1].window_begin, 7);
   }
@@ -89,9 +89,9 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     // Test copy assignment
     TriggerRecordHeader copy_assign_header = copy_header;
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_run_number(), 9);
-    BOOST_REQUIRE_EQUAL(copy_assign_header.get_error_bit(static_cast<TriggerRecordErrorBits>(0)), false);
-    BOOST_REQUIRE_EQUAL(copy_assign_header.get_error_bit(static_cast<TriggerRecordErrorBits>(1)), true);
-    BOOST_REQUIRE_EQUAL(copy_assign_header.get_header().error_bits, 10);
+    BOOST_REQUIRE_EQUAL(copy_assign_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
+    BOOST_REQUIRE_EQUAL(copy_assign_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
+    BOOST_REQUIRE_EQUAL(copy_assign_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(copy_assign_header.at(0).window_begin, 3);
     BOOST_REQUIRE_EQUAL(copy_assign_header[1].window_begin, 7);
   }
@@ -101,9 +101,9 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     TriggerRecordHeader buffer_header(buff, false);
 
     BOOST_REQUIRE_EQUAL(buffer_header.get_run_number(), 9);
-    BOOST_REQUIRE_EQUAL(buffer_header.get_error_bit(static_cast<TriggerRecordErrorBits>(0)), false);
-    BOOST_REQUIRE_EQUAL(buffer_header.get_error_bit(static_cast<TriggerRecordErrorBits>(1)), true);
-    BOOST_REQUIRE_EQUAL(buffer_header.get_header().error_bits, 10);
+    BOOST_REQUIRE_EQUAL(buffer_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
+    BOOST_REQUIRE_EQUAL(buffer_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
+    BOOST_REQUIRE_EQUAL(buffer_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(buffer_header.at(0).window_begin, 3);
     BOOST_REQUIRE_EQUAL(buffer_header[1].window_begin, 7);
   }
@@ -136,8 +136,8 @@ BOOST_AUTO_TEST_CASE(HeaderFields)
   header->set_trigger_number(10);
   header->set_trigger_timestamp(11);
   header->set_trigger_type(12);
-  header->set_error_bit(TriggerRecordErrorBits::kMismatch, true);
-  header->set_error_bit(TriggerRecordErrorBits::kUnassigned3, true);
+  header->set_status_bit(TriggerRecordStatusBits::kMismatch, true);
+  header->set_status_bit(TriggerRecordStatusBits::kUnassigned3, true);
 
   auto header_data = header->get_header();
   BOOST_REQUIRE_EQUAL(header->get_run_number(), header_data.run_number);
@@ -176,8 +176,8 @@ BOOST_AUTO_TEST_CASE(Header_SerDes_MsgPack)
   header->set_trigger_number(10);
   header->set_trigger_timestamp(11);
   header->set_trigger_type(12);
-  header->set_error_bit(TriggerRecordErrorBits::kMismatch, true);
-  header->set_error_bit(TriggerRecordErrorBits::kUnassigned3, true);
+  header->set_status_bit(TriggerRecordStatusBits::kMismatch, true);
+  header->set_status_bit(TriggerRecordStatusBits::kUnassigned3, true);
 
   auto bytes = dunedaq::serialization::serialize(*header, dunedaq::serialization::kMsgPack);
   TriggerRecordHeader& header_orig = *header;
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(Header_SerDes_MsgPack)
   BOOST_REQUIRE_EQUAL(header_orig.get_trigger_timestamp(), header_deserialized.get_trigger_timestamp());
   BOOST_REQUIRE_EQUAL(header_orig.get_num_requested_components(), header_deserialized.get_num_requested_components());
   BOOST_REQUIRE_EQUAL(header_orig.get_run_number(), header_deserialized.get_run_number());
-  BOOST_REQUIRE_EQUAL(header_orig.get_error_bits(), header_deserialized.get_error_bits());
+  BOOST_REQUIRE_EQUAL(header_orig.get_status_bits(), header_deserialized.get_status_bits());
   BOOST_REQUIRE_EQUAL(header_orig.get_trigger_type(), header_deserialized.get_trigger_type());
   BOOST_REQUIRE_EQUAL(header_orig.get_total_size_bytes(), header_deserialized.get_total_size_bytes());
   BOOST_REQUIRE_EQUAL(header_orig.at(0).window_begin, header_deserialized.at(0).window_begin);


### PR DESCRIPTION

# Description

Main PR: https://github.com/DUNE-DAQ/daqdataformats/pull/78
Issue: https://github.com/DUNE-DAQ/daqdataformats/issues/66