### PR TITLE
JCF: DUNE-DAQ/daqdataformats#79: drop references to daqdataformats::T…

### DIFF
--- a/unittest/TriggerRecordHeader_serialization_test.cxx
+++ b/unittest/TriggerRecordHeader_serialization_test.cxx
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
 
   {
     // Test copy constructor
-    TriggerRecordHeader copy_copy_header(copy_header);
+    TriggerRecordHeader copy_copy_header(copy_header); // NOLINT // performance-unnecessary-copy-initialization
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_run_number(), 9);
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
   }
   {
     // Test copy assignment
-    TriggerRecordHeader copy_assign_header = copy_header;
+    TriggerRecordHeader copy_assign_header = copy_header; // NOLINT // performance-unnecessary-copy-initialization
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_run_number(), 9);
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_status_bit(static_cast<TriggerRecordStatusBits>(0)), false);
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);

--- a/unittest/TriggerRecordHeader_serialization_test.cxx
+++ b/unittest/TriggerRecordHeader_serialization_test.cxx
@@ -59,7 +59,6 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
   header->set_status_bit(TriggerRecordStatusBits::kUnassigned3, true);
 
   BOOST_REQUIRE_THROW(header->at(header->get_header().num_requested_components), std::range_error);
-  BOOST_REQUIRE_THROW((*header)[header->get_header().num_requested_components], std::range_error);
 
   void* buff = malloc(header->get_total_size_bytes());
   memcpy(buff, header->get_storage_location(), header->get_total_size_bytes());
@@ -73,7 +72,6 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
   BOOST_REQUIRE_EQUAL(copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
   BOOST_REQUIRE_EQUAL(copy_header.get_header().status_bits, 10);
   BOOST_REQUIRE_EQUAL(copy_header.at(0).window_begin, 3);
-  BOOST_REQUIRE_EQUAL(copy_header[1].window_begin, 7);
 
   {
     // Test copy constructor
@@ -83,7 +81,6 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
     BOOST_REQUIRE_EQUAL(copy_copy_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(copy_copy_header.at(0).window_begin, 3);
-    BOOST_REQUIRE_EQUAL(copy_copy_header[1].window_begin, 7);
   }
   {
     // Test copy assignment
@@ -93,7 +90,6 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
     BOOST_REQUIRE_EQUAL(copy_assign_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(copy_assign_header.at(0).window_begin, 3);
-    BOOST_REQUIRE_EQUAL(copy_assign_header[1].window_begin, 7);
   }
 
   {
@@ -105,7 +101,6 @@ BOOST_AUTO_TEST_CASE(ExistingHeader)
     BOOST_REQUIRE_EQUAL(buffer_header.get_status_bit(static_cast<TriggerRecordStatusBits>(1)), true);
     BOOST_REQUIRE_EQUAL(buffer_header.get_header().status_bits, 10);
     BOOST_REQUIRE_EQUAL(buffer_header.at(0).window_begin, 3);
-    BOOST_REQUIRE_EQUAL(buffer_header[1].window_begin, 7);
   }
 
   BOOST_REQUIRE_EQUAL(*reinterpret_cast<uint32_t*>(buff), // NOLINT


### PR DESCRIPTION
…riggerRecordHeader::operator[] in unit tests due to its removal

# Description
Basically, in the unit tests we drop references to `daqdataformats::ComponentRequest::operator[]` as this function has been removed for reasons described in DUNE-DAQ/daqdataformats#81.

To review, make sure the code continues to build and its unit tests pass while building alongside the `johnfreeman/daqdataformats_issue79_code_refactoring` branch of `daqdataformats`

This is meant to be merged at the same time as https://github.com/DUNE-DAQ/daqdataformats/pull/81.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [X] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

I suppose this is an optimization in the sense that, once https://github.com/DUNE-DAQ/daqdataformats/pull/81 is merged, `dfmessages` won't compile without it. 
## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

